### PR TITLE
Remove kubic repositories

### DIFF
--- a/.github/install_latest_podman.sh
+++ b/.github/install_latest_podman.sh
@@ -1,7 +1,3 @@
-# https://podman.io/getting-started/installation
-. /etc/os-release
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -sSfL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 sudo apt-get update
 sudo apt-get -y upgrade
 sudo apt-get -y install podman


### PR DESCRIPTION
Signed-off-by: divyansh42 <diagrawa@redhat.com>

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
As kubic repositories are no longer maintained, removing that from test workflows.
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
https://github.com/redhat-actions/buildah-build/issues/93
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [x] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
