### PR TITLE
action: Update to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ inputs:
     default: 'true'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
### Description

See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Related Issue(s)

N/A

### Checklist

- [ ] This PR includes a documentation change
- [X] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Update to Node 16. Not sure if that means that we need to update the action version or not.