### PR TITLE
Bump NodeJS to version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ inputs:
     default: 'true'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
### Description

NodeJS 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates NodeJS to version 16.

### Related Issue(s)

Fixes gh-29

### Checklist

- [ ] This PR includes a documentation change
- [X ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [X ] This PR's changes are already tested
---
- [X ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Update NodeJS version used by the action from 12 to 16.
