### PR TITLE
getDockerConfigJson(): Return empty auth when `~/.docker/config.json` doesn't exist

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,5 +69,6 @@ export async function execute(
 
 export async function getDockerConfigJson(): Promise<string> {
     const dockerConfigPath = path.join(os.homedir(), ".docker", "config.json");
-    return fs.readFile(dockerConfigPath, "utf-8");
+    return fs.readFile(dockerConfigPath, "utf-8")
+        .catch((err) => { if (err.code === 'ENOENT') { return '{"auths":{}}'; } throw err; });
 }


### PR DESCRIPTION
### Description

Fixes `getDockerConfigJson()` raising an `ENOENT` error if `~/.docker/config.json` doesn't exist (#18).

This frequently happens with GitHub-hosted runners, but not always. I don't know why `~/.docker/config.json` sometimes doesn't exist, but it lets workflows fail pretty often - what is annoying.

Some examples: [(1)](https://github.com/SGSGermany/nextcloud/actions/runs/7234613214/job/19711159183#step:4:29), [(2)](https://github.com/SGSGermany/mariadb/actions/runs/7234457288/job/19710853648#step:4:29), [(3)](https://github.com/SGSGermany/acme/actions/runs/7227424502/job/19695061253#step:4:31) (note that the other parallel jobs succeeded...), [(4)](https://github.com/SGSGermany/weechat/actions/runs/7227416951/job/19695030362#step:4:29), [(5)](https://github.com/SGSGermany/ubuntu/actions/runs/7227193750/job/19694337379#step:4:31) (again, note the parallel job), [(6)](https://github.com/SGSGermany/alpine/actions/runs/7227170384/job/19694265731#step:4:31) (more parallel...), [(7)](https://github.com/SGSGermany/php-fpm/actions/runs/7215015007/job/19658394587#step:4:30) (again), [(8)](https://github.com/SGSGermany/debian/actions/runs/7214768802/job/19657583084#step:4:31) (and again) - all just within the last three days (unusually frequent though, normally it's once or twice a week or so...)

These changes are **UNTESTED!** Simply because I don't know how. I know a little JavaScript, but have next to zero experience with NodeJS (and honestly don't want to learn it), so please keep this in mind. I just figured that providing at least something to fix #18 is better than nothing.

The issue might be that not just `~/.docker/config.json` is missing, but the whole `~/.docker` folder. If that's the case, `fs.writeFile()` will fail [here](https://github.com/redhat-actions/podman-login/blob/a7d8d3e6447c1d7ea679172c7d10c7723d49dbf4/src/index.ts#L93) as well, requiring another fix. Since the issue isn't always reproducible it's hard to know... Fixing one issue first, trying whether the fix is complete and then possibly fix the other is probably easier than investing hours into debugging.

### Related Issue(s)

Fixes #18
Related to #36

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
- [x] What tests?
---
- [x] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Fixes `getDockerConfigJson()` raising an `ENOENT` error if `~/.docker/config.json` doesn't exist (#18)
