### PR TITLE
Don't fail on missing `~/.docker` dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ import { Inputs } from "./generated/inputs-outputs";
 
 let podmanPath: string | undefined;
 let registry: string;
-const dockerConfigPath = path.join(os.homedir(), ".docker", "config.json");
+const dockerConfigDir = path.join(os.homedir(), ".docker");
+const dockerConfigPath = path.join(dockerConfigDir, "config.json");
 
 async function getPodmanPath(): Promise<string> {
     if (podmanPath == null) {
@@ -91,7 +92,8 @@ async function run(): Promise<void> {
 
     dockerConfig.auths[registry] = generatedAuth;
 
-    await fs.writeFile(dockerConfigPath, JSON.stringify(dockerConfig, undefined, 8), "utf-8");
+    await fs.mkdir(dockerConfigDir, { recursive: true })
+        .then(() => fs.writeFile(dockerConfigPath, JSON.stringify(dockerConfig, undefined, 8), "utf-8"));
 }
 
 async function registryLogout(): Promise<void> {


### PR DESCRIPTION
### Description

This is the then announced "might be necessary, idk…" follow-up to #39 (8828a2343efc255ad6682f4cd9db89ad021b6de9). See #39 for background info.

Fixes the main `run()` raising an `ENOENT` error if `~/.docker/` doesn't exist when writing the new Docker config (#42).

This time I can't really say that it happens "frequently" with GitHub-hosted runners, it has been 5 months since @divyansh42 merged my initial (and apparently incomplete) fix (#39) in March. Still no idea why `~/.docker/` sometimes doesn't exist… Still it causes workflows to fail, what still is annoying. The last error happened in a private repo's workflow, thus I can't share the link…

These changes are again **UNTESTED!** Simply because I still don't know how. I still know a little JavaScript, but still have next to zero experience with NodeJS (and honestly don't want to learn it), so please keep this in mind. I still believe that providing something to fix #42 is better than nothing (so many "still"s :laughing:).

### Related Issue(s)

Fixes #42
Follow-up to #39
Related to #18
Related to #36 (maybe?)
Related to #41 (maybe?)

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
- [x] What tests?
---
- [x] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Fixes `run()` raising an `ENOENT` error if `~/.docker/` doesn't exist (fixes #42, follow-up to #39)
