### PR TITLE
Update to Node24.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run lint
 
@@ -22,7 +22,7 @@ jobs:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -50,7 +50,7 @@ jobs:
         install_latest: [ true, false ]
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -76,7 +76,7 @@ jobs:
         install_latest: [ true, false ]
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check links in markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install CRDA
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -13,10 +13,10 @@ jobs:
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # podman-login Changelog
 
+## v1.8
+- Update action to run on Node24. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+
 ## v1.7
 - Update action to run on Node20.https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ inputs:
     default: 'true'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'


### PR DESCRIPTION
### Description
Update use of Node.js from version 20 to 24. Version 20 is deprecated, see
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Related Issue(s)
Fixes #48 

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [x] This change is a major (breaking) change

### Changes made
- Use Node 24 instead of 20.
- Update two GitHub Actions to their latest major release.