### PR TITLE
Modernize CI workflows with latest actions and best practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,40 @@
 name: CI checks
 on:
   push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npm run lint
 
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install
         run: npm ci
@@ -35,11 +47,11 @@ jobs:
 
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,10 +1,18 @@
 name: Test Login and Pull
 on:
   push:
+    branches: [main]
   pull_request_target:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   IMAGE_PATH: quay.io/redhat-github-actions/petclinic-private:latest
@@ -15,7 +23,7 @@ env:
 jobs:
   podman-pull:
     name: Log in and pull image with Podman
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +31,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -43,14 +51,14 @@ jobs:
 
   buildah-pull:
     name: Log in and pull image with Buildah
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         install_latest: [ true, false ]
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -69,14 +77,14 @@ jobs:
 
   docker-pull:
     name: Log in and pull image with Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         install_latest: [ true, false ]
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -1,6 +1,7 @@
 name: Link checker
 on:
   push:
+    branches: [main]
     paths:
       - '**.md'
   pull_request:
@@ -9,12 +10,19 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -7,16 +7,19 @@ on:
   # schedule:
   #   - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 jobs:
   crda-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` v6 -> v7 and `actions/setup-node` v6 -> v7
- Add workflow-level `permissions: contents: read` (least privilege) to all workflows
- Add concurrency groups (`${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`) to prevent redundant runs
- Add path filters: `ci.yml` ignores markdown-only changes, `example.yml` scopes push to main branch
- Pin `runs-on` to `ubuntu-24.04` instead of `ubuntu-latest` for reproducibility

## Test plan

- [ ] CI workflows pass on this PR
- [ ] Verify concurrency groups cancel redundant runs
- [ ] Confirm path filters correctly skip workflows on markdown-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)