### PR TITLE
Add security policy, Dependabot, and harden repo settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report vulnerabilities through GitHub's private vulnerability reporting feature:
+
+1. Go to the [Security tab](https://github.com/redhat-actions/podman-login/security) of this repository
+2. Click "Report a vulnerability"
+3. Fill out the form with details about the vulnerability
+
+Alternatively, you can contact the Red Hat Product Security team at secalert@redhat.com.
+
+## Supported Versions
+
+Only the latest major version is actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v1.x    | Yes                |


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with vulnerability reporting instructions (GitHub private reporting + Red Hat secalert)
- Add `.github/dependabot.yml` to automate weekly dependency updates for npm packages and GitHub Actions
- Enable secret scanning and push protection (applied via API)
- Set default workflow token permissions to read-only (applied via API)
- Disable workflow-run PR approval (applied via API)

## Test plan

- [x] Secret scanning enabled: verified via `gh api repos/redhat-actions/podman-login`
- [x] Push protection enabled: verified via API response
- [x] Default workflow permissions set to `read`: verified via API
- [ ] Dependabot creates initial PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)