### PR TITLE
Update @types/node to 26.1.1 and exclude TypeScript 7 from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@redhat-actions/action-io-generator": "^1.5.0",
-        "@types/node": "^22",
+        "@types/node": "^26.1.1",
         "@vercel/ncc": "^0.44.1",
         "eslint": "^10.7.0",
         "typescript": "^6.0.3",
@@ -645,13 +645,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@redhat-actions/action-io-generator": "^1.5.0",
-    "@types/node": "^22",
+    "@types/node": "^26.1.1",
     "@vercel/ncc": "^0.44.1",
     "eslint": "^10.7.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

- Bump `@types/node` from 22.x to 26.1.1
- Add Dependabot ignore rule for TypeScript major version bumps -- TypeScript 7 has breaking changes (removes `moduleResolution: "node"`, among others) and needs a deliberate migration

## Test plan

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm run bundle` produces the dist bundle
- [ ] CI workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)