### PR TITLE
Remove blanket apt-get upgrade from CI install script

### DIFF
--- a/.github/install_latest_podman.sh
+++ b/.github/install_latest_podman.sh
@@ -1,3 +1,2 @@
 sudo apt-get update
-sudo apt-get -y upgrade
 sudo apt-get -y install podman


### PR DESCRIPTION
## Summary
- Removes `apt-get -y upgrade` from `.github/install_latest_podman.sh`
- This line was upgrading every package on the runner (Firefox, Chrome, PHP, Mesa, GTK themes, snaps, etc.), causing the CI job to time out
- `apt-get update && apt-get install podman` is sufficient to get the latest podman available in the runner's repos

Fixes the timeout in CI run https://github.com/redhat-actions/podman-login/actions/runs/31509886329/job/93840747842

## Test plan
- [ ] CI passes without timing out
- [ ] Podman is successfully installed and login/pull tests complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)